### PR TITLE
New usability features

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -79,6 +79,17 @@
   max-width: 180px; /* Slightly wider for readability */
   font-weight: 500; /* Makes names stand out */
 }
+
+.player-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.player-link:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 #leaderboardTable td:nth-child(3) {
   text-align: center; /* Centers MMR values */
   font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -17,10 +17,18 @@
 
     <main>
       <!-- Input Section -->
-      <div class="profile-input">
-        <input type="number" id="accountInput" min="0" inputmode="numeric" aria-label="Enter Account ID" placeholder="Enter Account ID">
-        <button onclick="fetchPlayerData()">Get Profile</button>
-      </div>
+      <form class="profile-input" onsubmit="fetchPlayerData(); return false;">
+        <input
+          id="accountInput"
+          name="accountId"
+          min="0"
+          inputmode="numeric"
+          aria-label="Enter Account ID"
+          placeholder="Enter Account ID"
+          autocomplete="on"
+        >
+        <button type="submit">Get Profile</button>
+      </form>
 
       <!-- Button to Open Help Modal -->
       <section class="help-modal-button">

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -67,9 +67,18 @@ function displayLeaderboard(playerEntries) {
         const row = document.createElement("tr");
         row.innerHTML = `
             <td>#${(player.rank ?? 0) + 1}</td>
-            <td>${player.displayName ?? "Unknown"}</td>
+            <td><a href="?accountId=${player.accountId}" class="player-link">${player.displayName ?? "Unknown"}</a></td>
             <td>${player.score ?? "N/A"}</td>
         `;
+
+        // Add click handler to prevent default navigation and handle profile loading
+        const link = row.querySelector('.player-link');
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
+            document.getElementById("accountInput").value = player.accountId;
+            fetchPlayerData();
+            closeSidebar(); // Close sidebar after selection
+        });
         leaderboardList.appendChild(row);
     });
 }


### PR DESCRIPTION
 - Add accountId to search params to allow users to bookmark page + refresh page
 - Added browser history for when viewing multiple projects, can now use browser back and forward (does hit the `isFetching` multiple requests limit if doing it too quick)
 - Used html form to allow for auto complete field of previously entered accountIds
 - Added links to leaderboard entries to go to leaderboard account's id page
 - Update page title to account's displayName